### PR TITLE
Private Isuのインスタンス名変更

### DIFF
--- a/oci/env/main/isucon-instance.tf
+++ b/oci/env/main/isucon-instance.tf
@@ -8,7 +8,7 @@ module "private-isu" {
 }
 
 module "private-isu2" {
-  name           = "isucon10q-updated"
+  name           = "private-isu2"
   source         = "../../modules/isucon/instance"
   compartment-id = oci_identity_compartment.main-compartment.id
   subnet_id      = oci_core_subnet.isucon-default.id
@@ -16,7 +16,7 @@ module "private-isu2" {
 }
 
 module "private-isu-bench" {
-  name           = "isucon11q"
+  name           = "private-isu-bench"
   source         = "../../modules/isucon/instance"
   compartment-id = oci_identity_compartment.main-compartment.id
   subnet_id      = oci_core_subnet.isucon-default.id


### PR DESCRIPTION
- **✨ accept user_data variable in isucon-instance**
- **🔧 configure user_data, isucon11q for isu1**
- **✨ init file for private-isu, isucon10q**
- **🔧 update source_id default to ubuntu22.04**
- **🔧 add private_ip variable, instance_id output to isucon-instance template**
- **🧱 update isucon instances**
- **🔧 remove display_name, is_pv_encryption_in_transit_enabled from instance config**
- **🧱 Update infra for private-isu**
- **🔧 change instance name**
