### PR TITLE
[main-kms] Specify rotation details for KMS

### DIFF
--- a/oci/env/main/main-kms.tf
+++ b/oci/env/main/main-kms.tf
@@ -12,6 +12,9 @@ resource "oci_kms_key" "main" {
     algorithm = "AES"
     length    = 32
   }
+  auto_key_rotation_details {
+    rotation_interval_in_days = 30
+  }
   management_endpoint      = oci_kms_vault.main.management_endpoint
   is_auto_rotation_enabled = true
   protection_mode          = "HSM"


### PR DESCRIPTION
## What

- Creation of compute instance 2024-1 was failed due to empty rotation_details in main-kms
- This PR resolves the issue and tries the creation of 2024-1

## Summary by PR Agent

### 🤖 Generated by PR Agent at 4fad5eb3fa71965e1205286cd021e6f3b1477fcb

- Added `auto_key_rotation_details` block to the `oci_kms_key` resource in `main-kms.tf` to specify key rotation details.
- Configured `rotation_interval_in_days` to 30, ensuring automatic key rotation is properly defined.
- This fixes an issue where key rotation details were not explicitly specified.


## Walkthrough by PR Agent

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main-kms.tf</strong><dd><code>Specify key rotation interval for KMS key resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

oci/env/main/main-kms.tf

<li>Added <code>auto_key_rotation_details</code> block to specify key rotation details.<br> <li> Set <code>rotation_interval_in_days</code> to 30 for automatic key rotation.<br>


</details>


  </td>
  <td><a href="https://github.com/Shion1305/Shion1305-infra/pull/32/files#diff-d555323da829c3af8711cde3584ab0ed254b9298a9c1dfed62ef9b397c64957a">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information