### PR TITLE
[main-kms] Disable Key rotation

### DIFF
--- a/oci/env/main/main-kms.tf
+++ b/oci/env/main/main-kms.tf
@@ -12,10 +12,6 @@ resource "oci_kms_key" "main" {
     algorithm = "AES"
     length    = 32
   }
-  auto_key_rotation_details {
-    rotation_interval_in_days = 30
-  }
   management_endpoint      = oci_kms_vault.main.management_endpoint
-  is_auto_rotation_enabled = true
   protection_mode          = "HSM"
 }


### PR DESCRIPTION
## What

- Creation of compute instance 2024-1 was failed due to main-kms configuration error.
- This PR removes key rotation config and retry creation of the instance.

## Summary by PR Agent

### 🤖 Generated by PR Agent at a1fc73eb83ad5b9ed222e30507cd4bb105b66538

- Fixed a configuration error in the `main-kms` setup that caused the creation of a compute instance to fail.
- Removed the `auto_key_rotation_details` block and disabled automatic key rotation in the KMS configuration.
- Ensured compatibility for compute instance creation by updating the KMS configuration.


## Walkthrough by PR Agent

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main-kms.tf</strong><dd><code>Disable automatic key rotation in KMS configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

oci/env/main/main-kms.tf

<li>Removed the <code>auto_key_rotation_details</code> block, including the <br><code>rotation_interval_in_days</code> setting.<br> <li> Disabled automatic key rotation by removing the <br><code>is_auto_rotation_enabled</code> property.<br>


</details>


  </td>
  <td><a href="https://github.com/Shion1305/Shion1305-infra/pull/33/files#diff-d555323da829c3af8711cde3584ab0ed254b9298a9c1dfed62ef9b397c64957a">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information