### PR TITLE
[modules/main/compute] Fix compute module configuration

### DIFF
--- a/oci/env/main/main-kms.tf
+++ b/oci/env/main/main-kms.tf
@@ -6,7 +6,7 @@ resource "oci_kms_vault" "main" {
 
 resource "oci_kms_key" "main" {
   compartment_id = oci_identity_compartment.main-compartment.id
-  display_name   = "main_key"
+  display_name   = "main_key_aes"
   key_shape {
     #Required
     algorithm = "AES"

--- a/oci/env/main/oci_compute_instance-2024.tf
+++ b/oci/env/main/oci_compute_instance-2024.tf
@@ -14,6 +14,6 @@ module "oci_compute_instance-2024" {
   availability_domain       = "kbTA:AP-TOKYO-1-AD-1"
   hostname_label            = "instance-2024-1"
   image_id                  = "ocid1.image.oc1.ap-tokyo-1.aaaaaaaax3arbzsjtoqovmp56hfba3q2qyxljbci6ejkuagmkjql6ej3mj6q"
-  kms_key_id                = oci_kms_key.main.id
+  kms_key_id                = null
   preserve_boot_volume      = true
 }

--- a/oci/modules/main/compute/main.tf
+++ b/oci/modules/main/compute/main.tf
@@ -5,24 +5,46 @@ resource "oci_core_instance" "this" {
   display_name         = var.display_name
   shape                = var.shape
   preserve_boot_volume = var.preserve_boot_volume
-
+  agent_config {
+    are_all_plugins_disabled = false
+    is_management_disabled   = false
+    is_monitoring_disabled   = false
+  }
+  availability_config {
+    is_live_migration_preferred = true
+    recovery_action             = "RESTORE_INSTANCE"
+  }
+  launch_options {
+    boot_volume_type                    = "PARAVIRTUALIZED"
+    firmware                            = "UEFI_64"
+    is_consistent_volume_naming_enabled = true
+    network_type                        = "PARAVIRTUALIZED"
+    remote_data_volume_type             = "PARAVIRTUALIZED"
+  }
   shape_config {
-    ocpus         = var.ocpus
-    memory_in_gbs = var.memory_in_gbs
+    baseline_ocpu_utilization = null
+    memory_in_gbs             = var.memory_in_gbs
+    ocpus                     = var.ocpus
+    vcpus                     = var.vcpus
   }
 
   create_vnic_details {
-    hostname_label            = var.hostname_label
     subnet_id                 = var.subnet_id
+    display_name              = var.display_name
     assign_public_ip          = var.assign_public_ip
+    skip_source_dest_check    = true
     private_ip                = var.private_ip
+    hostname_label            = var.hostname_label
     assign_private_dns_record = var.assign_private_dns_record
   }
 
   source_details {
-    source_type = "image"
-    source_id   = var.image_id
-    kms_key_id  = var.kms_key_id
+    boot_volume_size_in_gbs = jsonencode(50)
+    boot_volume_vpus_per_gb = jsonencode(10)
+    is_preserve_boot_volume_enabled = false
+    source_id                       = var.image_id
+    source_type                     = "image"
+    kms_key_id                      = var.kms_key_id
   }
 
   metadata = {

--- a/oci/modules/main/compute/variable.tf
+++ b/oci/modules/main/compute/variable.tf
@@ -32,6 +32,12 @@ variable "shape" {
   default     = "VM.Standard.A1.Flex"
 }
 
+variable "vcpus" {
+  type        = number
+  description = "Number of vCPUs for the instance shape_config."
+  default     = 1
+}
+
 variable "ocpus" {
   type        = number
   description = "Number of OCPUs for the instance shape_config."


### PR DESCRIPTION
## What

- There were some missing and incorrect confiugration for [modules/main/compute]
- Added and updated properties as required.

## Summary by PR Agent

### 🤖 Generated by PR Agent at 648636e6d6e6de45250fc9a5fcc85c118597be3c

- Updated the `oci_kms_key` resource in `main-kms.tf` to use a more descriptive `display_name` ("main_key_aes").
- Removed the KMS key association from the `oci_compute_instance-2024` module by setting `kms_key_id` to `null`.
- Enhanced the `oci_core_instance` resource in the compute module with new configurations:
  - Added `agent_config`, `availability_config`, and `launch_options` blocks.
  - Improved `shape_config` with `baseline_ocpu_utilization` and `vcpus`.
  - Updated `create_vnic_details` and `source_details` with additional configurations.
- Introduced a new variable `vcpus` in the compute module to allow specifying the number of vCPUs.


## Walkthrough by PR Agent

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main-kms.tf</strong><dd><code>Update KMS key display name for better clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

oci/env/main/main-kms.tf

<li>Updated the <code>display_name</code> of the <code>oci_kms_key</code> resource to <br>"main_key_aes".<br>


</details>


  </td>
  <td><a href="https://github.com/Shion1305/Shion1305-infra/pull/34/files#diff-d555323da829c3af8711cde3584ab0ed254b9298a9c1dfed62ef9b397c64957a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Enhance compute module with additional configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

oci/modules/main/compute/main.tf

<li>Added <code>agent_config</code>, <code>availability_config</code>, and <code>launch_options</code> blocks to <br>the <code>oci_core_instance</code> resource.<br> <li> Enhanced <code>shape_config</code> with <code>baseline_ocpu_utilization</code> and <code>vcpus</code>.<br> <li> Updated <code>create_vnic_details</code> with <code>skip_source_dest_check</code> and reordered <br>variables.<br> <li> Enhanced <code>source_details</code> with additional boot volume configurations.<br>


</details>


  </td>
  <td><a href="https://github.com/Shion1305/Shion1305-infra/pull/34/files#diff-c718d0917af61b1fcd5b7af5afad28c2fa1678a49e13615417968f21fd8dedf9">+29/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>variable.tf</strong><dd><code>Add vCPUs variable to compute module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

oci/modules/main/compute/variable.tf

- Added a new variable `vcpus` for specifying the number of vCPUs.



</details>


  </td>
  <td><a href="https://github.com/Shion1305/Shion1305-infra/pull/34/files#diff-b2308495fb900785c206ce6c2121e07aa1e65e2502ed6dfe35528e755ed1c85d">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oci_compute_instance-2024.tf</strong><dd><code>Remove KMS key association from compute instance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

oci/env/main/oci_compute_instance-2024.tf

<li>Set <code>kms_key_id</code> to <code>null</code> for the <code>oci_compute_instance-2024</code> module.<br>


</details>


  </td>
  <td><a href="https://github.com/Shion1305/Shion1305-infra/pull/34/files#diff-92007daab93975b9e347e394d7272be346f2c6cb7fa2e12581db4fee86eb4aca">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information