### PR TITLE
🧱 increase capacity for oci_compute_instance-2024-1

### DIFF
--- a/oci/env/main/oci_compute_instance-2024.tf
+++ b/oci/env/main/oci_compute_instance-2024.tf
@@ -7,8 +7,8 @@ module "oci_compute_instance-2024" {
   assign_private_dns_record = true
   assign_public_ip          = true
   display_name              = "oci_compute_instance-2024-1"
-  ocpus                     = 1
-  memory_in_gbs             = 6
+  ocpus                     = 2
+  memory_in_gbs             = 12
   shape                     = "VM.Standard.A1.Flex"
   fault_domain              = "FAULT-DOMAIN-1"
   availability_domain       = "kbTA:AP-TOKYO-1-AD-1"


### PR DESCRIPTION
## What

Increase capacity for oci_compute_instance-2024-1
vCPU:2
RAM:12

## Summary by PR Agent

### 🤖 Generated by PR Agent at 86621e1c55a56fb842c740ba15f95a43cd2fa8ac

- Increased the capacity of the `oci_compute_instance-2024` module in the Terraform configuration.
- Updated `ocpus` from 1 to 2 and `memory_in_gbs` from 6 to 12 to enhance the instance's performance.


## Walkthrough by PR Agent

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oci_compute_instance-2024.tf</strong><dd><code>Increased compute instance capacity in Terraform configuration</code></dd></summary>
<hr>

oci/env/main/oci_compute_instance-2024.tf

<li>Increased <code>ocpus</code> from 1 to 2.<br> <li> Increased <code>memory_in_gbs</code> from 6 to 12.


</details>


  </td>
  <td><a href="https://github.com/Shion1305/Shion1305-infra/pull/35/files#diff-92007daab93975b9e347e394d7272be346f2c6cb7fa2e12581db4fee86eb4aca">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information