### PR TITLE
🔧 Open port 6443

### DIFF
--- a/oci/env/main/main-security-list.tf
+++ b/oci/env/main/main-security-list.tf
@@ -4,9 +4,9 @@ resource "oci_core_security_list" "main-security-list" {
     "Oracle-Tags.CreatedBy" = "shion1305@gmail.com"
     "Oracle-Tags.CreatedOn" = "2021-11-10T01:32:16.204Z"
   }
-  display_name  = "Default Security List for vcn-20211110-1031"
+  display_name = "Default Security List for vcn-20211110-1031"
   freeform_tags = {}
-  vcn_id        = oci_core_vcn.main-vcn.id
+  vcn_id       = oci_core_vcn.main-vcn.id
   egress_security_rules {
     description      = null
     destination      = "0.0.0.0/0"
@@ -16,7 +16,7 @@ resource "oci_core_security_list" "main-security-list" {
   }
   ingress_security_rules {
     description = null
-    protocol    = jsonencode(1)
+    protocol = jsonencode(1)
     source      = "10.0.0.0/16"
     source_type = "CIDR_BLOCK"
     stateless   = false
@@ -27,7 +27,7 @@ resource "oci_core_security_list" "main-security-list" {
   }
   ingress_security_rules {
     description = null
-    protocol    = jsonencode(1)
+    protocol = jsonencode(1)
     source      = "0.0.0.0/0"
     source_type = "CIDR_BLOCK"
     stateless   = false
@@ -38,7 +38,7 @@ resource "oci_core_security_list" "main-security-list" {
   }
   ingress_security_rules {
     description = null
-    protocol    = jsonencode(6)
+    protocol = jsonencode(6)
     source      = "0.0.0.0/0"
     source_type = "CIDR_BLOCK"
     stateless   = false
@@ -49,7 +49,7 @@ resource "oci_core_security_list" "main-security-list" {
   }
   ingress_security_rules {
     description = null
-    protocol    = jsonencode(6)
+    protocol = jsonencode(6)
     source      = "0.0.0.0/0"
     source_type = "CIDR_BLOCK"
     stateless   = false
@@ -60,7 +60,7 @@ resource "oci_core_security_list" "main-security-list" {
   }
   ingress_security_rules {
     description = null
-    protocol    = jsonencode(6)
+    protocol = jsonencode(6)
     source      = "0.0.0.0/0"
     source_type = "CIDR_BLOCK"
     stateless   = false
@@ -71,13 +71,24 @@ resource "oci_core_security_list" "main-security-list" {
   }
   ingress_security_rules {
     description = null
-    protocol    = jsonencode(6)
+    protocol = jsonencode(6)
     source      = "0.0.0.0/0"
     source_type = "CIDR_BLOCK"
     stateless   = true
     tcp_options {
       max = 4914
       min = 4914
+    }
+  }
+  ingress_security_rules {
+    description = null
+    protocol = jsonencode(6)
+    source      = "0.0.0.0/0"
+    source_type = "CIDR_BLOCK"
+    stateless   = true
+    tcp_options {
+      max = 6443
+      min = 6443
     }
   }
 }


### PR DESCRIPTION
## What

Opening port 6443 for k8s

## Summary by PR Agent

### 🤖 Generated by PR Agent at 6e58e15e05c846f7d4a0429c13c63f1267e876c3

- Added a new ingress security rule to open port 6443 in the `oci_core_security_list` resource.
- The new rule is stateless, uses the TCP protocol, and applies to all sources (`0.0.0.0/0`).
- Minor formatting adjustments were made to improve code consistency.


## Walkthrough by PR Agent

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main-security-list.tf</strong><dd><code>Add ingress rule to open port 6443</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

oci/env/main/main-security-list.tf

<li>Added a new ingress security rule to open port 6443.<br> <li> Ensured the new rule is stateless and applies to TCP protocol.<br> <li> Adjusted formatting inconsistencies in the file.


</details>


  </td>
  <td><a href="https://github.com/Shion1305/Shion1305-infra/pull/36/files#diff-9110bb1d011cd7315549a7e8d32b628b334bce6d11f36f586800b04d0d08f953">+19/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information