### PR TITLE
🔧 Reconfigure vcpu for oci_compute_instance-2024

### DIFF
--- a/oci/env/main/oci_compute_instance-2024.tf
+++ b/oci/env/main/oci_compute_instance-2024.tf
@@ -8,6 +8,7 @@ module "oci_compute_instance-2024" {
   assign_public_ip          = true
   display_name              = "oci_compute_instance-2024-1"
   ocpus                     = 2
+  vcpus                     = 2
   memory_in_gbs             = 12
   shape                     = "VM.Standard.A1.Flex"
   fault_domain              = "FAULT-DOMAIN-1"


### PR DESCRIPTION
## What

- Reconfigure vcpu to align with current configuration

## Summary by PR Agent

### 🤖 Generated by PR Agent at c0b02431ef4595cee8413d1a4cea4e399226ce49

- Added a new `vcpus` parameter to the `oci_compute_instance-2024` module configuration in `oci/env/main/oci_compute_instance-2024.tf`.
- Ensured the `vcpus` parameter aligns with the `ocpus` parameter, both set to 2.
- This change enhances the configuration by explicitly defining the `vcpus` parameter for better clarity and alignment with current standards.


## Walkthrough by PR Agent

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oci_compute_instance-2024.tf</strong><dd><code>Add `vcpus` parameter to compute instance configuration</code>&nbsp; &nbsp; </dd></summary>
<hr>

oci/env/main/oci_compute_instance-2024.tf

<li>Added a new <code>vcpus</code> parameter with a value of 2.<br> <li> Ensured alignment with the <code>ocpus</code> parameter for the compute instance <br>module.


</details>


  </td>
  <td><a href="https://github.com/Shion1305/Shion1305-infra/pull/37/files#diff-92007daab93975b9e347e394d7272be346f2c6cb7fa2e12581db4fee86eb4aca">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information