### PR TITLE
Upgrade `shion1305-ops` instance with 3vCPU, 18 GB

### DIFF
--- a/oci/env/main/oci_compute_instance-2024.tf
+++ b/oci/env/main/oci_compute_instance-2024.tf
@@ -7,9 +7,9 @@ module "oci_compute_instance-ops" {
   assign_private_dns_record = true
   assign_public_ip          = true
   display_name              = "oci_compute_instance-ops"
-  ocpus                     = 2
-  vcpus                     = 2
-  memory_in_gbs             = 12
+  ocpus                     = 3
+  vcpus                     = 3
+  memory_in_gbs             = 18
   shape                     = "VM.Standard.A1.Flex"
   fault_domain              = "FAULT-DOMAIN-1"
   availability_domain       = "kbTA:AP-TOKYO-1-AD-1"


### PR DESCRIPTION
## What

This PR upgrades shion1305-ops instance with 3vCPU and 18GB

## Summary by PR Agent

pr_agent:summary

## Walkthrough by PR Agent

pr_agent:walkthrough
