### PR TITLE
🧱 removing vcpu param for shion1305-ops, as it is invalid param when ocpu exist

### DIFF
--- a/oci/env/main/oci_compute_instance-2024.tf
+++ b/oci/env/main/oci_compute_instance-2024.tf
@@ -8,7 +8,6 @@ module "oci_compute_instance-ops" {
   assign_public_ip          = true
   display_name              = "oci_compute_instance-ops"
   ocpus                     = 3
-  vcpus                     = 3
   memory_in_gbs             = 18
   shape                     = "VM.Standard.A1.Flex"
   fault_domain              = "FAULT-DOMAIN-1"


### PR DESCRIPTION
## What

shion1305-ops instance holds both params for vcpu and ocpu. vcpu is invalid in this case as it is not using the param.


## Summary by PR Agent

### 🤖 Generated by PR Agent at d44da35b1edb380dd6c4d564de1921db69178905

- Remove invalid `vcpus` parameter from ops instance


## Walkthrough by PR Agent

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oci_compute_instance-2024.tf</strong><dd><code>Remove vcpus parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

oci/env/main/oci_compute_instance-2024.tf

<li>Deleted <code>vcpus</code> configuration line<br> <li> Retained existing <code>ocpus</code> allocation


</details>


  </td>
  <td><a href="https://github.com/Shion1305/Shion1305-infra/pull/43/files#diff-92007daab93975b9e347e394d7272be346f2c6cb7fa2e12581db4fee86eb4aca">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>