### PR TITLE
🐛 (oci/modules/main/compute) Remove vcpu param

### DIFF
--- a/oci/modules/main/compute/main.tf
+++ b/oci/modules/main/compute/main.tf
@@ -25,7 +25,6 @@ resource "oci_core_instance" "this" {
     baseline_ocpu_utilization = null
     memory_in_gbs             = var.memory_in_gbs
     ocpus                     = var.ocpus
-    vcpus                     = var.vcpus
   }
 
   create_vnic_details {

--- a/oci/modules/main/compute/variable.tf
+++ b/oci/modules/main/compute/variable.tf
@@ -32,12 +32,6 @@ variable "shape" {
   default     = "VM.Standard.A1.Flex"
 }
 
-variable "vcpus" {
-  type        = number
-  description = "Number of vCPUs for the instance shape_config."
-  default     = 1
-}
-
 variable "ocpus" {
   type        = number
   description = "Number of OCPUs for the instance shape_config."


### PR DESCRIPTION
vcpu param is specified for module (oci/modules/main/compute) but the param is conflicting with ocpu value

## What

oci compute custom defined module has both vcpu and ocpu param specified but these are conflicting. Removing vcpu value here.

## Summary by PR Agent

pr_agent:summary

## Walkthrough by PR Agent

pr_agent:walkthrough
