### PR TITLE
📄 update private IP address for OCI compute instance configuration

### DIFF
--- a/oci/env/main/oci_compute_instance-2024.tf
+++ b/oci/env/main/oci_compute_instance-2024.tf
@@ -1,7 +1,7 @@
 module "oci_compute_instance-k8s" {
   source                    = "../../modules/main/compute"
   subnet_id                 = oci_core_subnet.main-subnet.id
-  private_ip                = "10.0.0.20"
+  private_ip                = "10.0.7.20"
   compartment_id            = oci_identity_compartment.main-compartment.id
   ssh_authorized_keys       = var.ssh_keys
   assign_private_dns_record = true


### PR DESCRIPTION
## What

This updates ip address of k8s.

## Summary by PR Agent

### 🤖 Generated by PR Agent at f47ba9e5dac0afc8239a435a5a721958b25d9373

- Update k8s instance private IP address
- Adjust OCI compute instance configuration


## Walkthrough by PR Agent

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oci_compute_instance-2024.tf</strong><dd><code>Update compute instance private IP</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

oci/env/main/oci_compute_instance-2024.tf

<ul><li>Change <code>private_ip</code> from <code>10.0.0.20</code> to <code>10.0.7.20</code><br> <li> Keep other compute instance settings unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/Shion1305/Shion1305-infra/pull/50/files#diff-92007daab93975b9e347e394d7272be346f2c6cb7fa2e12581db4fee86eb4aca">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>