### PR TITLE
🔧 (oci) Disable destroy prevention on k8s block volume

### DIFF
--- a/oci/env/main/oci_block_volumes.tf
+++ b/oci/env/main/oci_block_volumes.tf
@@ -6,7 +6,7 @@ resource "oci_core_volume" "k8s-block-volume" {
   vpus_per_gb         = 0
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = false
   }
 }
 


### PR DESCRIPTION
## What

Disable destroy prevention on block volume on k8s node as we're decommissioning the volume

## Summary by PR Agent

pr_agent:summary

## Walkthrough by PR Agent

pr_agent:walkthrough
