### PR TITLE
🧱 (oci) Merge Block Volumes on OCI instances into k8s-proxy

### DIFF
--- a/oci/env/main/oci_block_volumes.tf
+++ b/oci/env/main/oci_block_volumes.tf
@@ -1,32 +1,13 @@
-resource "oci_core_volume" "k8s-block-volume" {
-  compartment_id      = oci_identity_compartment.main-compartment.id
-  availability_domain = module.oci_compute_instance-k8s.availability_domain
-  display_name        = "k8s-block-volume"
-  size_in_gbs         = 50
-  vpus_per_gb         = 0
-
-  lifecycle {
-    prevent_destroy = false
-  }
-}
-
 resource "oci_core_volume" "k8s-proxy-block-volume" {
   compartment_id      = oci_identity_compartment.main-compartment.id
   availability_domain = module.oci_compute_instance-k8s-proxy.availability_domain
   display_name        = "k8s-proxy-block-volume"
-  size_in_gbs         = 50
+  size_in_gbs         = 100
   vpus_per_gb         = 0
 
   lifecycle {
     prevent_destroy = true
   }
-}
-
-resource "oci_core_volume_attachment" "k8s-block-volume-attachment" {
-  attachment_type = "paravirtualized"
-  instance_id     = module.oci_compute_instance-k8s.ocid
-  volume_id       = oci_core_volume.k8s-block-volume.id
-  display_name    = "k8s-block-volume-attachment"
 }
 
 resource "oci_core_volume_attachment" "k8s-proxy-block-volume-attachment" {


### PR DESCRIPTION
## What

This PR removes block volume on k8s controlplane, merges into k8s-proxy

## Summary by PR Agent

pr_agent:summary

## Walkthrough by PR Agent

pr_agent:walkthrough
