### PR TITLE
⚖️ (oci) Balance OCPU/memory between instance-2024-1 and instance-k8s-proxy

### DIFF
--- a/oci/env/main/oci_compute_instance-2024.tf
+++ b/oci/env/main/oci_compute_instance-2024.tf
@@ -7,8 +7,8 @@ module "oci_compute_instance-k8s" {
   assign_private_dns_record = true
   assign_public_ip          = true
   display_name              = "oci_compute_instance-k8s"
-  ocpus                     = 3
-  memory_in_gbs             = 18
+  ocpus                     = 2
+  memory_in_gbs             = 12
   shape                     = "VM.Standard.A1.Flex"
   fault_domain              = "FAULT-DOMAIN-1"
   availability_domain       = "kbTA:AP-TOKYO-1-AD-1"

--- a/oci/env/main/oci_compute_instance-k8s-proxy.tf
+++ b/oci/env/main/oci_compute_instance-k8s-proxy.tf
@@ -7,8 +7,8 @@ module "oci_compute_instance-k8s-proxy" {
   assign_private_dns_record = true
   assign_public_ip          = true
   display_name              = "oci_compute_instance-k8s-proxy"
-  ocpus                     = 1
-  memory_in_gbs             = 6
+  ocpus                     = 2
+  memory_in_gbs             = 12
   shape                     = "VM.Standard.A1.Flex"
   fault_domain              = "FAULT-DOMAIN-1"
   availability_domain       = "kbTA:AP-TOKYO-1-AD-1"


### PR DESCRIPTION
## What

Rebalance OCPU and memory between the two A1.Flex k8s nodes from an uneven split to equal halves.

| Instance | Before | After |
|---|---|---|
| `instance-2024-1` | 3 OCPU / 18 GB | 2 OCPU / 12 GB |
| `instance-k8s-proxy` | 1 OCPU / 6 GB | 2 OCPU / 12 GB |
| Total | 4 OCPU / 24 GB | 4 OCPU / 24 GB (unchanged) |

## Why

`instance-k8s-proxy` was undersized: 1 OCPU running ~46 pods (8 Longhorn, 4 ArgoCD, etc.), with load average ≥ 3.95 (≥400% saturated). This caused kubelet probe timeouts cluster-wide — ArgoCD components crashlooped, Keycloak hit 352 restarts, and the broken `keycloak-cert-sync` job spammed Error pods. Meanwhile `instance-2024-1` had headroom.

Splitting evenly removes the bottleneck so the kube-scheduler can use both nodes as roughly equivalent destinations.

## Notes

- A1.Flex shapes allow live resize, but each instance needs a stop/start to apply the new shape config. Plan a brief reboot per node (drain → stop → start → uncordon).
- Total quota use is unchanged; this is a redistribution, not a scale-up.

## Test plan

- [ ] `terragrunt plan` shows only `ocpus` / `memory_in_gbs` in-place updates on the two compute modules
- [ ] `terragrunt apply` succeeds
- [ ] `kubectl describe node instance-k8s-proxy` reports `cpu: 2`, `memory: ~12Gi`
- [ ] `kubectl describe node instance-2024-1` reports `cpu: 2`, `memory: ~12Gi`
- [ ] Pods on both nodes return Ready; ArgoCD/Keycloak crashloops resolve