### PR TITLE
👷 (ci) Allow manual trigger of OCI plan workflow

### DIFF
--- a/.github/workflows/tf-plan-oci.yaml
+++ b/.github/workflows/tf-plan-oci.yaml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'oci/**'
       - '.github/workflows/tf-plan-oci.yaml'
+  workflow_dispatch:
 jobs:
   run-terragrunt-plan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Add `workflow_dispatch` to `tf-plan-oci.yaml` so the OCI plan workflow can be triggered manually.

## Why

Sometimes the plan needs to be re-run against a PR without pushing a new commit (e.g. after fixing external state or transient failures).

## How it works

Run via **Actions → Run Plan on OCI → Run workflow**, selecting the PR's **head branch**. `tfwrapper.sh`'s `tfcmt` auto-detects the associated PR from the branch/SHA and posts the plan result as a comment — same mechanism as the existing `pull_request` trigger.

Mirrors the `workflow_dispatch` already present in `tf-apply-oci.yaml`.